### PR TITLE
Update Client.php

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Exception\RequestException;
 use yii\base\Component;
 use yii\base\InvalidConfigException;
 use yii\helpers\ArrayHelper;
+use yii\helpers\Json;
 
 /**
  * Class Client is the base class of all objects in library. Handles common requests and Guzzle PHP client initialization.
@@ -79,7 +80,7 @@ class Client extends Component
 
 			return $this->format == 'xml'
 				? $response->xml()
-				: $response->json();
+				: Json::decode($response->getBody(), true);
 
 		} catch (RequestException $e) {
 			return null;


### PR DESCRIPTION
Guzzle 6 does not includes anymore the json() method for response. 
This is because of psr7 implementation.
